### PR TITLE
Added rsvg-convert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 # Install Imagemagick
 RUN apk add --no-cache file
-RUN apk --update add imagemagick imagemagick-pdf
+RUN apk --update add imagemagick imagemagick-pdf rsvg-convert
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Adding rsvg-convert in order to enable SVG conversions (e.g. converting an `.svg` to a `.ico` file).